### PR TITLE
Allow line breaks within messages.

### DIFF
--- a/shell/messenger/bin/message_processor
+++ b/shell/messenger/bin/message_processor
@@ -46,7 +46,7 @@ class Oggetto_Shell_Messenger_Message_Processor extends Oggetto_Shell_Messenger_
             Mage::app()->addEventArea('adminhtml');
 
             $stdin = fopen('php://stdin', 'r');
-            $message = unserialize(fgets($stdin));
+            $message = unserialize(stream_get_contents($stdin));
             if ($message instanceof Oggetto_Messenger_Model_Message_Interface) {
 
                 $transport = new Varien_Object();


### PR DESCRIPTION
`fgets` was causing message parsing to fail when the message contained line breaks within properties (e.g. product descriptions). 

I'm not sure if `stream_get_contents` is the best solution or not, but it seems to work. I assume `fwrite` in the queue_processor sends an EOL.
