### PR TITLE
Allow setting magento home environment variable

### DIFF
--- a/shell/messenger/abstract.php
+++ b/shell/messenger/abstract.php
@@ -21,10 +21,10 @@
  * @copyright  Copyright (C) 2012 Oggetto Web (http://oggettoweb.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-
-require_once __DIR__ . '/../abstract.php';
-require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../../lib/Varien/Profiler.php';
+define('MAGE_HOME', ($path = getenv('MAGE_HOME')) ? $path : realpath(__DIR__.'/../../'));
+require_once MAGE_HOME.'/shell/abstract.php';
+require_once MAGE_HOME.'/vendor/autoload.php';
+require_once MAGE_HOME.'/lib/Varien/Profiler.php';
 
 /**
  * Abstract messenger shell class

--- a/shell/messenger/receiver.php
+++ b/shell/messenger/receiver.php
@@ -21,9 +21,9 @@
  * @copyright  Copyright (C) 2012 Oggetto Web (http://oggettoweb.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-
-require_once __DIR__ . '/../abstract.php';
-require_once __DIR__ . '/../../vendor/autoload.php';
+define('MAGE_HOME', ($path = getenv('MAGE_HOME')) ? $path : realpath(__DIR__.'/../../'));
+require_once MAGE_HOME . '/shell/abstract.php';
+require_once MAGE_HOME . '/vendor/autoload.php';
 
 use Symfony\Component\Yaml\Yaml;
 


### PR DESCRIPTION
This is to account for situations where messenger is included in the codebase via symlink.

requiring shell/abstract.php doesn't work as it is in a different real path to the messenger code.

E.g. composer with symlink strategy. Magento composer installer copy strategy has a lot of drawbacks such as file mappings going haywire.

The path of least resistance is to allow MAGE_HOME to be specified when running the scripts. e.g. MAGE_HOME=/path/to/magento/public php messenger/receiver.php stop --queues test:1:d

Any other ideas?
